### PR TITLE
fix(app-opine): regression with graphql route

### DIFF
--- a/packages/app-opine/mod.js
+++ b/packages/app-opine/mod.js
@@ -14,6 +14,7 @@ export default function (services) {
   app.use(hyperRouter(services));
   // GQL
   app.use(
+    "/graphql",
     hyperGqlRouter({
       playground: (playground && playground !== "false") ||
         env !== "production",

--- a/packages/app-opine/router.js
+++ b/packages/app-opine/router.js
@@ -108,7 +108,6 @@ export function hyperRouter(services) {
   app.delete("/crawler/:bucket/:name", bindCore, crawler.del);
 
   app.get("/error", (_req, _res, next) => {
-    console.log("oooooo");
     next(new Error("Error occuried"));
   });
 

--- a/packages/app-opine/test/mod_test.js
+++ b/packages/app-opine/test/mod_test.js
@@ -16,3 +16,10 @@ Deno.test("GET /", async () => {
 
   assertEquals(res.body.name, "hyper63");
 });
+
+Deno.test("GET /graphql", async () => {
+  await superdeno(app)
+    .get("/graphql")
+    .set("Accept", "text/html") // ask for the playground
+    .expect(200);
+});


### PR DESCRIPTION
Something happened with the change to `app-opine` that's causing the graphql route to not mount correctly. This explicitly mounts on `/graphql` and adds a test to assert graphql is always mounted.